### PR TITLE
[Enhancement] update last.updated via workflow

### DIFF
--- a/.github/tests/vrt/template-paths.js
+++ b/.github/tests/vrt/template-paths.js
@@ -27,7 +27,8 @@ var scenarioPaths = {};
 scenarioPaths.paths = [
     {
         "label":"Vegan chocolate and nut brownies",
-        "path": "en/recipes/vegan-chocolate-and-nut-brownies/"
+        "path": "en/recipes/vegan-chocolate-and-nut-brownies/",
+        "delay": 2000,
     },
     {
         "label": "Category: Healthy",

--- a/.github/workflows/last-updated.yaml
+++ b/.github/workflows/last-updated.yaml
@@ -1,0 +1,31 @@
+name: Update last.updated
+on:
+  push:
+    branches:
+      - main
+      - master
+jobs:
+  update-last-updated-file:
+    name: "Updates the last.updated file with the current date"
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'platformsh-templates' && github.event.commits[0].author.name != 'GitHub Action' }}
+    steps:
+      - name: 'get repo'
+        id: prepautopr
+        uses: actions/checkout@v3
+        with:
+          token: ${{secrets.TEMPLATES_GITHUB_TOKEN }}
+      - name: 'set git config'
+        shell: bash
+        run: |
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+      - name: 'update last.updated'
+        id: last-updated
+        shell: bash
+        run: |
+          date > ./.platform/last.updated
+          git add ./.platform/last.updated
+          git commit -m "auto-updates version, post merge"
+          git push origin main
+


### PR DESCRIPTION
## Description
adds workflow to update the ./.platform/last.updated file with the current Date for better tracking of what version of the template a customer is using

## Motivation and Context
Customers creating projects from these templates get a copy of this repository. After that, there is no connection back to this template. Since these templates are constantly being improved, in attempting to assist customers using our templates, it would be helpful to know what version of the template they started from. The simplest, least intrusive method is to add a date stamp to a file so we can compare that date with merges. from there we'll have a solid idea of what they're working with. 

## How Has This Been Tested?
https://github.com/gilzow/inject-post-merge/actions

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] I have read the contribution guide
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
