### PR TITLE
executes the drush deploy script with bash directly instead of assuming the script has the execute permission

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -86,7 +86,7 @@ hooks:
         #   - `updatedb`
         #   - and if config files are present, `config-import`
         cd web
-        $PLATFORM_APP_DIR/drush/platformsh_deploy_drupal.sh
+        bash $PLATFORM_APP_DIR/drush/platformsh_deploy_drupal.sh
 
 # The configuration of app when it is exposed to the web.
 web:


### PR DESCRIPTION
## Description
executes the drush deploy script with bash directly instead of assuming the script has the execute permission
See https://github.com/platformsh/template-builder/pull/830/
## Related Issue
#25 

### Please drop a link to the issue here:
#25 

## Motivation and Context
Does not work if someone copies the files w/o the permission 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] I have read the contribution guide
- [X] I have created an issue following the issue guide
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
