### PR TITLE
adds #block-umami-footer-promo img to removeselectors

### DIFF
--- a/.github/tests/vrt/template-paths.js
+++ b/.github/tests/vrt/template-paths.js
@@ -28,6 +28,7 @@ scenarioPaths.paths = [
     {
         "label": "Home",
         "delay": 2000,
+        "removeSelectors": ['#block-umami-footer-promo img']
     },
     {
         "label": "Forced 404",


### PR DESCRIPTION
 since 3 out of 10 times it fails to load in time and causes the VRT to fail
