### PR TITLE
Add custom mailer command for Drupal Symfony Mailer

### DIFF
--- a/web/sites/default/settings.platformsh.php
+++ b/web/sites/default/settings.platformsh.php
@@ -163,3 +163,12 @@ foreach ($platformsh->variables() as $name => $value) {
       break;
   }
 }
+
+// Drupal Symfony Mailer (contrib)
+// Platform.sh provides msmtp to intercept sendmail emails and forward them to
+// Sendgrid. Since the msmtp doesn't work with the default -bs sendmail option,
+// you should use the custom command ini_get('sendmail_path').
+// @see: https://www.drupal.org/docs/contributed-modules/drupal-symfony-mailer/getting-started#s-platformsh
+$settings['mailer_sendmail_commands'] = [
+  ini_get('sendmail_path'),
+];


### PR DESCRIPTION
## Description
Given that [Drupal Symfony Mailer](https://www.drupal.org/project/symfony_mailer) is the de-facto choise for HTML emails in D10, and that the [inclusion of Symfony Mailer in Drupal core is being discussed](https://www.drupal.org/project/drupal/issues/3380476), I propose to add this small piece of configuration required in the Drupal 10 Platform.sh template.
It adds a custom command, that will need to be selected in the configuration when creating a Sendmail transport [as described in the official documentation](https://www.drupal.org/docs/contributed-modules/drupal-symfony-mailer/getting-started#s-platformsh).
NB: the parameters `-t -i` are not necessary since they're inherited by the `sendmail_path`.


## Related Issue
#85 

### Please drop a link to the issue here:

## Motivation and Context
It provides a piece of configuration required and that is Platform.sh specific, for a module that is not in core but likely installed.
https://www.drupal.org/docs/contributed-modules/drupal-symfony-mailer/getting-started#s-platformsh

## How Has This Been Tested?
HTML emails are being sent on my Platform.sh instance.

## Screenshots (if appropriate):

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
 Go over all the following list, and put an `x` in all the boxes that apply. If you're unsure about what any of these mean, don't hesitate to ask. We're here to help!

- [x] I have read the contribution guide
- [x] I have created an issue following the issue guide
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
