### PR TITLE
allow static serving of webp and avif

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -115,7 +115,7 @@ web:
             # Rules for specific URI patterns.
             rules:
                 # Allow access to common static files.
-                '\.(jpe?g|png|gif|svgz?|css|js|map|ico|bmp|eot|woff2?|otf|ttf)$':
+                '\.(avif|webp|jpe?g|png|gif|svgz?|css|js|map|ico|bmp|eot|woff2?|otf|ttf)$':
                     allow: true
                 '^/robots\.txt$':
                     allow: true


### PR DESCRIPTION
## Description
adds webp and avif to allowed static files. Partially addresses #104 

## Related Issue
#104 

## Motivation and Context
Please note this only allows for serving of static webp and avif files and does not address manipulation of either of these file types.