### PR TITLE
Add default configuration for RabbitMQ

### DIFF
--- a/web/sites/default/settings.platformsh.php
+++ b/web/sites/default/settings.platformsh.php
@@ -92,6 +92,33 @@ if ($platformsh->hasRelationship('redis') && !InstallerKernel::installationAttem
   ];
 }
 
+// Enable RabbitMQ configuration and default queue.
+if ($platformsh->hasRelationship('rabbitmq') && class_exists(' Drupal\rabbitmq\Queue\Queue')) {
+  $rabbitmq = $platformsh->credentials('rabbitmq');
+
+  $settings['rabbitmq_credentials']['default'] = [
+    'host' => $rabbitmq['host'],
+    'port' => $rabbitmq['port'],
+    'vhost' => '/',
+    'username' => $rabbitmq['username'],
+    'password' => $rabbitmq['password'],
+    // Uncomment the lines below if you are using AMQP over SSL.
+    /*
+    'ssl' => [
+      'verify_peer_name' => FALSE,
+      'verify_peer' => FALSE,
+      'local_pk' => '~/.ssh/id_rsa',
+    ],
+     */
+    'options' => [
+      'connection_timeout' => 5,
+      'read_write_timeout' => 5,
+    ],
+  ];
+
+  $settings['queue_default'] = 'queue.rabbitmq.default';
+}
+
 if ($platformsh->inRuntime()) {
   // Configure private and temporary file paths.
   if (!isset($settings['file_private_path'])) {


### PR DESCRIPTION
## Description
Provide default configuration for the Drupal rabbitmq module based on a rabbitmq service relationship.

## Related Issue
Currently no default configuration or standard integration provided between rabbitmq and Drupal.

### Please drop a link to the issue here:
https://github.com/platformsh-templates/drupal10/issues/112

## Motivation and Context
Saves repeated set up of rabbitmq service integration.

## How Has This Been Tested?
I have configured and tested on p.sh using this code. I have populated and processed queues.

## Screenshots (if appropriate):

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
 Go over all the following list, and put an `x` in all the boxes that apply. If you're unsure about what any of these mean, don't hesitate to ask. We're here to help!

- [x] I have read the contribution guide
- [x] I have created an issue following the issue guide
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
