### PR TITLE
removes config_sync_directory setting from settings.php to settings.platformsh.php

### DIFF
--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -27,11 +27,6 @@ $settings['file_scan_ignore_directories'] = [
 // local development.
 // $settings['hash_salt'] = 'change_me';
 
-// Set up a config sync directory.
-//
-// This is defined inside the read-only "config" directory, deployed via Git.
-$settings['config_sync_directory'] = '../config/sync';
-
 // Automatic Platform.sh settings.
 if (file_exists($app_root . '/' . $site_path . '/settings.platformsh.php')) {
   include $app_root . '/' . $site_path . '/settings.platformsh.php';

--- a/web/sites/default/settings.platformsh.php
+++ b/web/sites/default/settings.platformsh.php
@@ -8,6 +8,11 @@ use Drupal\Core\Installer\InstallerKernel;
 
 $platformsh = new \Platformsh\ConfigReader\Config();
 
+// Set up a config sync directory.
+//
+// This is defined inside the read-only "config" directory, deployed via Git.
+$settings['config_sync_directory'] = '../config/sync';
+
 // Configure the database.
 if ($platformsh->hasRelationship('database')) {
   $creds = $platformsh->credentials('database');


### PR DESCRIPTION
## Description
removes config_sync_directory setting from settings.php to settings.platformsh.php

## Related Issue
#142 
Closes #142 

## Motivation and Context
`config_sync_directory` is a required setting in order to deploy on platform.sh
`settings.php` should be a trimmed copy of default.settings.php + an include to the platformsh settings file.
With `config_sync_directory` being in settings.php, a user can't include our setting's file and drop it into their codebase without having to also modify it, or their settings.php.  


