### PR TITLE
adds state_cache true to settings.php

### DIFF
--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -18,6 +18,8 @@ $settings['file_scan_ignore_directories'] = [
   'node_modules',
   'bower_components',
 ];
+// @see https://www.drupal.org/node/3177901
+$settings['state_cache'] = TRUE;
 
 // The hash_salt should be a unique random value for each application.
 // If left unset, the settings.platformsh.php file will attempt to provide one.


### PR DESCRIPTION
## Description
the settings `$settings['state_cache']` was added in v10.3.0 of Drupal. See more info in the issue.

## Related Issue
#161 

