### PR TITLE
Composer version should be a valid constraint not ^2.1

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -11,7 +11,7 @@ type: 'php:8.2'
 
 dependencies:
     php:
-        composer/composer: '^2.1'
+        composer/composer: '^2'
 
 runtime:
     # Enable the redis extension so Drupal can communicate with the Redis cache.


### PR DESCRIPTION

## Description
The current constraint here is invalid, composer has never supported a 2.1 branch (there is a 2.2). I'm not sure how this can work, but it seems that platform may try and fail to use 2.1, so just uses 2.8.x currently instead.

## Related Issue
This project only accepts pull requests related to open issues.
- If suggesting a new feature or change, please discuss it in an issue first
- If fixing a bug, there should be an issue describing it with steps to reproduce it following the bug report guide
- If you're suggesting a feature, please follow the feature request guide by clicking on issues

### Please drop a link to the issue here:

* https://github.com/platformsh-templates/drupal10/issues/179

## Motivation and Context

Use a valid composer version.

## How Has This Been Tested?
Please describe in detail how you tested your changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.

## Screenshots (if appropriate):

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
 Go over all the following list, and put an `x` in all the boxes that apply. If you're unsure about what any of these mean, don't hesitate to ask. We're here to help!

- [ ] I have read the contribution guide
- [ ] I have created an issue following the issue guide
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
